### PR TITLE
Relax Rack dependency.

### DIFF
--- a/rack-restful_submit.gemspec
+++ b/rack-restful_submit.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.files = `git ls-files`.split("\n")
   s.require_paths = ["lib"]
-  s.add_dependency "rack", "~>1.3.0"
+  s.add_dependency "rack", "~>1.3"
   s.add_development_dependency 'rspec', '~>2.6.0'
 end
 


### PR DESCRIPTION
Since rack-restful_submit is using only one, the most basic method of
Rack, there is no need to be so worried about API change.
