### PR TITLE
Fix test suite to pass against Rack 1.6+.

### DIFF
--- a/spec/rack-restful_submit_spec.rb
+++ b/spec/rack-restful_submit_spec.rb
@@ -18,8 +18,7 @@ describe Rack::RestfulSubmit do
   describe "a post request" do
     before do
       in_env['REQUEST_METHOD'] = 'POST'
-      in_env['rack.input'] = in_env['form_input'] = ''
-      in_env['rack.request.form_input'] = ''
+      in_env['rack.request.form_input'] = in_env['rack.input'] = in_env['form_input'] = StringIO.new('')
       in_env["rack.request.form_hash"] = {}
     end
 


### PR DESCRIPTION
Without this patch, all tests fail like:

```
  1) Rack::RestfulSubmit a post request with GET and valid mapping 
     Failure/Error: let(:out_env) { subject.call(in_env) }
     NoMethodError:
       undefined method `read' for "":String
     # /usr/share/gems/gems/rack-1.6.2/lib/rack/request.rb:208:in `POST'
     # /usr/share/gems/gems/rack-1.6.2/lib/rack/request.rb:230:in `params'
     # ./lib/rack/rack-restful_submit.rb:15:in `call'
     # ./spec/rack-restful_submit_spec.rb:9:in `block (2 levels) in <top (required)>'
     # ./spec/rack-restful_submit_spec.rb:40:in `block (5 levels) in <top (required)>'
  2) Rack::RestfulSubmit a post request with GET and valid mapping 
     Failure/Error: let(:out_env) { subject.call(in_env) }
     NoMethodError:
       undefined method `read' for "":String
     # /usr/share/gems/gems/rack-1.6.2/lib/rack/request.rb:208:in `POST'
     # /usr/share/gems/gems/rack-1.6.2/lib/rack/request.rb:230:in `params'
     # ./lib/rack/rack-restful_submit.rb:15:in `call'
     # ./spec/rack-restful_submit_spec.rb:9:in `block (2 levels) in <top (required)>'
     # ./spec/rack-restful_submit_spec.rb:41:in `block (5 levels) in <top (required)>'

...snip...

Finished in 0.03762 seconds (files took 0.19048 seconds to load)
85 examples, 83 failures
```

since according to documentation [1], the `rack.input` should be IO-like object.

[1] http://www.rubydoc.info/github/rack/rack/file/SPEC
