### PR TITLE
Support rack 2.x.

### DIFF
--- a/rack-restful_submit.gemspec
+++ b/rack-restful_submit.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.files = `git ls-files`.split("\n")
   s.require_paths = ["lib"]
-  s.add_dependency "rack", "~>1.3"
+  s.add_dependency "rack", [">= 1.3", "< 3"]
   s.add_development_dependency 'rspec', '~>2.6.0'
 end
 


### PR DESCRIPTION
Hi,
Could you merge this patch to support rack 2.x too?
Because I wanted to use rack latest version 2.0.1.

I could pass the unit test after this modification.

```
$ bundle install --path vendor/bundle

$ bundle list
Gems included by the bundle:
  * bundler (1.12.5)
  * diff-lcs (1.1.3)
  * rack (2.0.1)
  * rack-restful_submit (1.2.2)
  * rspec (2.6.0)
  * rspec-core (2.6.4)
  * rspec-expectations (2.6.0)
  * rspec-mocks (2.6.0)

$ bundle exec vendor/bundle/ruby/2.3.0/bin/rspec spec/
...
85 examples, 0 failures
```

I can recommend you to merge this pull-request after merging below pull-request, because it is easy to merge.
https://github.com/martincik/rack-restful_submit/pull/5

Thanks.
